### PR TITLE
#14 : ensure unique names are used for creating new elements

### DIFF
--- a/org.eclipse.triquetrum.workflow.editor/src/main/java/org/eclipse/triquetrum/workflow/editor/features/ConnectionCreateFeature.java
+++ b/org.eclipse.triquetrum.workflow.editor/src/main/java/org/eclipse/triquetrum/workflow/editor/features/ConnectionCreateFeature.java
@@ -16,6 +16,7 @@ import org.eclipse.graphiti.features.context.impl.AddConnectionContext;
 import org.eclipse.graphiti.features.impl.AbstractCreateConnectionFeature;
 import org.eclipse.graphiti.mm.pictograms.Anchor;
 import org.eclipse.graphiti.mm.pictograms.Connection;
+import org.eclipse.triquetrum.workflow.editor.util.EditorUtils;
 import org.eclipse.triquetrum.workflow.model.CompositeActor;
 import org.eclipse.triquetrum.workflow.model.Port;
 import org.eclipse.triquetrum.workflow.model.Relation;
@@ -90,12 +91,12 @@ public class ConnectionCreateFeature extends AbstractCreateConnectionFeature {
 
   /**
    * Creates a relation between two ports.
-   * 
+   *
    * @throws IllegalActionException
    */
   private Relation createRelation(Port source, Port target) throws IllegalActionException {
     Relation relation = TriqFactory.eINSTANCE.createRelation();
-    relation.setName("new_r");
+    relation.setName(EditorUtils.buildUniqueName(source, "_R"));
 //    relation.setContainer(source.getContainer().getContainer());
     relation.getLinkedPorts().add(source);
     relation.getLinkedPorts().add(target);

--- a/org.eclipse.triquetrum.workflow.editor/src/main/java/org/eclipse/triquetrum/workflow/editor/features/ModelElementCreateFeature.java
+++ b/org.eclipse.triquetrum.workflow.editor/src/main/java/org/eclipse/triquetrum/workflow/editor/features/ModelElementCreateFeature.java
@@ -28,7 +28,7 @@ import org.eclipse.triquetrum.workflow.model.TriqPackage;
 
 /**
  * Creates a new model element based on a drag-n-drop from the palette, after prompting the user for the name.
- * 
+ *
  */
 public class ModelElementCreateFeature extends AbstractCreateFeature {
 
@@ -72,7 +72,7 @@ public class ModelElementCreateFeature extends AbstractCreateFeature {
       // create new model element
       EClassifier eClassifier = TriqPackage.eINSTANCE.getEClassifier(elementClass);
       NamedObj result = (NamedObj) TriqFactory.eINSTANCE.create((EClass) eClassifier);
-      result.setName(elementName);
+      result.setName(EditorUtils.buildUniqueName(model, elementName));
       result.setWrappedType(wrappedClass);
 
       if (result instanceof Director) {


### PR DESCRIPTION
We can use ptolemy's CompositeEntity.uniqueName() in
ConnectionCreateFeature and ModelElementCreateFeature.

Signed-off-by: Erwin De Ley <erwindl0@gmail.com>