### PR TITLE
Summary: Removed @see tags to fix Eclipse triq.target build

### DIFF
--- a/org.eclipse.triquetrum.workflow.ui/src/main/java/org/eclipse/triquetrum/workflow/ui/AbstractPlaceableSWT.java
+++ b/org.eclipse.triquetrum.workflow.ui/src/main/java/org/eclipse/triquetrum/workflow/ui/AbstractPlaceableSWT.java
@@ -28,8 +28,6 @@ import ptolemy.kernel.util.NameDuplicationException;
 /**
  * Base class for SWT implementation of actors that implement PortablePlaceable.
  *
- * @see ptolemy.actor.gui.AbstractPlaceableJavaSE
- *
  * @author Erwin De Ley
  */
 

--- a/org.eclipse.triquetrum.workflow.ui/src/main/java/org/eclipse/triquetrum/workflow/ui/SizeAttribute.java
+++ b/org.eclipse.triquetrum.workflow.ui/src/main/java/org/eclipse/triquetrum/workflow/ui/SizeAttribute.java
@@ -37,7 +37,6 @@ import ptolemy.kernel.util.Workspace;
  * To record the size and position of the shell, use WindowPropertiesAttribute.
  *
  * @author Edward A. Lee,  Contributors: Erwin De Ley
- * @see ptolemy.actor.gui.SizeAttribute
  * @see WindowPropertiesAttribute
  */
 @SuppressWarnings("restriction")

--- a/org.eclipse.triquetrum.workflow.ui/src/main/java/org/eclipse/triquetrum/workflow/ui/WindowPropertiesAttribute.java
+++ b/org.eclipse.triquetrum.workflow.ui/src/main/java/org/eclipse/triquetrum/workflow/ui/WindowPropertiesAttribute.java
@@ -40,7 +40,6 @@ import ptolemy.kernel.util.Workspace;
  *
  * @author Edward A. Lee, Contributors: Jason E. Smith, Christopher Brooks, Erwin De Ley
  *
- * @see ptolemy.actor.gui.WindowPropertiesAttribute
  */
 @SuppressWarnings("restriction")
 public class WindowPropertiesAttribute extends Parameter implements ControlListener {


### PR DESCRIPTION
Bug 22: @see tags cause errors in Eclipse build

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>