### PR TITLE
Summary: Updating pom.xml to include javadoc module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <module>org.eclipse.triquetrum.workflow.model.editor</module>
     <module>org.eclipse.triquetrum.workflow.model.viewmodel</module>
     <module>org.eclipse.triquetrum.workflow.ui</module>
+    <module>javadoc</module>
   </modules>
 
   <repositories>


### PR DESCRIPTION
Bug #31 A support for JavaDoc to pom.xml

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>