### PR TITLE
#7 : fix MAC OSX focus-lost issue on text fields in EMF forms

### DIFF
--- a/org.eclipse.triquetrum.workflow.editor/src/main/java/org/eclipse/triquetrum/workflow/editor/views/NamedObjDialog.java
+++ b/org.eclipse.triquetrum.workflow.editor/src/main/java/org/eclipse/triquetrum/workflow/editor/views/NamedObjDialog.java
@@ -73,6 +73,7 @@ public class NamedObjDialog extends Dialog {
 
   @Override
   public boolean close() {
+    view.getSWTControl().forceFocus();
     view.dispose();
     return super.close();
   }


### PR DESCRIPTION
The fix involves forcing the focus on the dialog view component, right before closing it.
Thanks to Davy De Durpel, for reproducing the reported issue, implementing the fix and testing it.

Christopher, can you try this out to see if it works for you as well?