### PR TITLE
Apparently, Links to wiki pages cannot have trailing slashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Besides delivering a generic workflow environment, Triquetrum also delivers exte
 
 ## Resources
 * [Downloads](https://wiki.eclipse.org/Triquetrum/Downloads)
-* [Wiki](https://wiki.eclipse.org/Triquetrum/)
+* [Wiki](https://wiki.eclipse.org/Triquetrum)


### PR DESCRIPTION
Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>