### PR TITLE
Fixed bug #86: Dragging a TrigFunction actor fails in the May 29 build

### DIFF
--- a/org.eclipse.triquetrum.workflow.editor.palette/plugin.xml
+++ b/org.eclipse.triquetrum.workflow.editor.palette/plugin.xml
@@ -141,6 +141,13 @@
              iconType="svg"
              type="Actor">
 	      </entry>
+	      <entry
+	            class="ptolemy.actor.lib.TrigFunction"
+	            displayName="TrigFunction"
+    	        icon="icons/actor.gif"
+	            type="Actor">
+	      </entry>
+
         <entry
               class="ptolemy.actor.lib.MovingAverage"
               displayName="MovingAverage"
@@ -148,12 +155,6 @@
               iconType="ptolemy"
               type="Actor">
         </entry>
-	      <entry
-	            class="ptolemy.actor.lib.TrigFunction"
-	            displayName="TrigFunction"
-    	        icon="icons/actor.gif"
-	            type="Actor">
-	      </entry>
       </group>
    </extension>
 


### PR DESCRIPTION
and throws an exception in the head

Oddly, moving the definition of TrigFunction ealier in the file fixed
this? 

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>