### PR TITLE
Issue #92: Use TPD file to generate TARGET files

### DIFF
--- a/org.eclipse.triquetrum.target.platform/README.md
+++ b/org.eclipse.triquetrum.target.platform/README.md
@@ -1,0 +1,6 @@
+Using Target Files
+==================
+
+The TPD editor should be used to edit/update the target file. The TPD editor is available from https://github.com/mbarbero/fr.obeo.releng.targetplatform.
+
+See https://wiki.eclipse.org/Triquetrum/Building_From_Sources#Building for more details.

--- a/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
+++ b/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
@@ -1,71 +1,72 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="triq" sequenceNumber="55">
-<locations>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.nebula.visualization.feature.feature.group" version="0.9.9.201601121647"/>
-<repository location="http://archive.eclipse.org/nebula/Q42015/release/"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group" version="1.9.0.20160606-1526"/>
-<unit id="org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group" version="1.9.0.20160606-1526"/>
-<repository location="http://download.eclipse.org/ecp/releases/releases_19/190/"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.equinox.sdk.feature.group" version="3.12.0.v20160606-1311"/>
-<unit id="org.eclipse.graphiti.feature.tools.feature.group" version="0.13.0.v20160608-1043"/>
-<unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.10.0.201606071900"/>
-<unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.12.0.v20160603-1336"/>
-<unit id="org.eclipse.platform.sdk" version="4.6.0.I20160606-1100"/>
-<unit id="org.eclipse.sdk.ide" version="4.6.0.I20160606-1100"/>
-<unit id="org.eclipse.net4j.ui.feature.group" version="4.2.300.v20160301-1326"/>
-<unit id="org.eclipse.emf.sdk.feature.group" version="2.12.0.v20160526-0356"/>
-<unit id="org.eclipse.emf.validation.feature.group" version="1.10.0.201606071713"/>
-<unit id="org.eclipse.platform.feature.group" version="4.6.0.v20160606-1342"/>
-<unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
-<unit id="org.eclipse.gef.sdk.feature.group" version="3.11.0.201606061308"/>
-<unit id="org.eclipse.gmf.feature.group" version="1.10.0.201606071959"/>
-<unit id="org.eclipse.ecf.core.feature.feature.group" version="1.3.0.v20160405-1820"/>
-<unit id="org.eclipse.emf.cdo.epp.feature.group" version="4.5.0.v20160607-1511"/>
-<unit id="org.eclipse.pde.source.feature.group" version="3.12.0.v20160606-1100"/>
-<unit id="org.eclipse.gmf.tooling.runtime.feature.group" version="3.3.1.201509291144"/>
-<unit id="org.eclipse.net4j.util.ui.feature.group" version="4.5.0.v20160607-1254"/>
-<unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.10.0.201606071631"/>
-<unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.13.0.v20160608-1043"/>
-<unit id="org.eclipse.ocl.all.feature.group" version="5.2.0.v20160523-1914"/>
-<unit id="org.eclipse.rcp.source.feature.group" version="4.6.0.v20160606-1342"/>
-<unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.13.0.v20160608-1043"/>
-<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.9.200.v20160606-1311"/>
-<unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
-<unit id="org.eclipse.platform.source.feature.group" version="4.6.0.v20160606-1342"/>
-<unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
-<unit id="org.eclipse.gmf.runtime.notation.source.feature.group" version="1.10.0.201606071631"/>
-<unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.13.1.v20160405-1820"/>
-<unit id="org.eclipse.jdt.source.feature.group" version="3.12.0.v20160606-1100"/>
-<unit id="org.eclipse.gmf.source.feature.group" version="1.10.0.201606071959"/>
-<unit id="org.eclipse.rcp.feature.group" version="4.6.0.v20160606-1342"/>
-<unit id="org.eclipse.core.runtime.feature.feature.group" version="1.1.200.v20160606-1342"/>
-<unit id="org.eclipse.graphiti.sdk.plus.feature.feature.group" version="0.13.0.v20160608-1043"/>
-<unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.13.1.v20160405-1820"/>
-<unit id="org.eclipse.gmf.tooling.runtime.source.feature.group" version="3.3.1.201509291144"/>
-<unit id="org.eclipse.graphiti.feature.feature.group" version="0.13.0.v20160608-1043"/>
-<repository location="http://download.eclipse.org/releases/neon"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.triquetrum.ptolemy.feature.source.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.triquetrum.ptolemy.feature.feature.group" version="0.0.0"/>
-<repository location="http://users.telenet.be/triquetrum-ptolemy-p2/"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.slf4j.impl.log4j12" version="1.7.2.v20131105-2200"/>
-<unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
-<unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
-<unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-<unit id="org.slf4j.api.source" version="1.7.2.v20121108-1250"/>
-<unit id="org.slf4j.impl.log4j12.source" version="1.7.2.v20131105-2200"/>
-<unit id="org.apache.commons.lang.source" version="2.6.0.v201404270220"/>
-<unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20151118145958/repository/"/>
-</location>
-</locations>
+<?pde?>
+<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
+<target name="Triq" sequenceNumber="1470176386">
+  <locations>
+    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.slf4j.impl.log4j12" version="1.7.2.v20131105-2200"/>
+      <unit id="org.slf4j.api.source" version="1.7.2.v20121108-1250"/>
+      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
+      <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+      <unit id="org.slf4j.impl.log4j12.source" version="1.7.2.v20131105-2200"/>
+      <unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
+      <unit id="org.apache.log4j.source" version="1.2.15.v201012070815"/>
+      <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
+      <unit id="org.apache.commons.lang.source" version="2.6.0.v201404270220"/>
+      <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
+      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.triquetrum.ptolemy.feature.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.triquetrum.ptolemy.feature.feature.group" version="0.0.0"/>
+      <repository location="http://users.telenet.be/triquetrum-ptolemy-p2/"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.nebula.visualization.feature.feature.group" version="0.9.9.201601121647"/>
+      <repository location="http://archive.eclipse.org/nebula/Q42015/release/"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.3.0.v20160405-1820"/>
+      <unit id="org.eclipse.emf.validation.feature.group" version="1.10.0.201606071713"/>
+      <unit id="org.eclipse.platform.source.feature.group" version="4.6.0.v20160606-1342"/>
+      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.12.0.v20160606-1311"/>
+      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.12.0.v20160603-1336"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.6.0.v20160606-1342"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.6.0.v20160606-1342"/>
+      <unit id="org.eclipse.ocl.all.feature.group" version="5.2.0.v20160523-1914"/>
+      <unit id="org.eclipse.rcp.source.feature.group" version="4.6.0.v20160606-1342"/>
+      <unit id="org.eclipse.emf.cdo.epp.feature.group" version="4.5.0.v20160607-1511"/>
+      <unit id="org.eclipse.pde.source.feature.group" version="3.12.0.v20160606-1100"/>
+      <unit id="org.eclipse.gef.sdk.feature.group" version="3.11.0.201606061308"/>
+      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.1.200.v20160606-1342"/>
+      <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.10.0.201606071900"/>
+      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.13.0.v20160608-1043"/>
+      <unit id="org.eclipse.gmf.runtime.notation.source.feature.group" version="1.10.0.201606071631"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.13.1.v20160405-1820"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.12.0.v20160526-0356"/>
+      <unit id="org.eclipse.gmf.source.feature.group" version="1.10.0.201606071959"/>
+      <unit id="org.eclipse.gmf.tooling.runtime.source.feature.group" version="3.3.1.201509291144"/>
+      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.13.0.v20160608-1043"/>
+      <unit id="org.eclipse.graphiti.feature.tools.feature.group" version="0.13.0.v20160608-1043"/>
+      <unit id="org.eclipse.jdt.source.feature.group" version="3.12.0.v20160606-1100"/>
+      <unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.13.0.v20160608-1043"/>
+      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.gmf.feature.group" version="1.10.0.201606071959"/>
+      <unit id="org.eclipse.net4j.util.ui.feature.group" version="4.5.0.v20160607-1254"/>
+      <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.9.200.v20160606-1311"/>
+      <unit id="org.eclipse.net4j.ui.feature.group" version="4.2.300.v20160301-1326"/>
+      <unit id="org.eclipse.gmf.tooling.runtime.feature.group" version="3.3.1.201509291144"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.13.1.v20160405-1820"/>
+      <unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.10.0.201606071631"/>
+      <unit id="org.eclipse.graphiti.sdk.plus.feature.feature.group" version="0.13.0.v20160608-1043"/>
+      <repository location="http://download.eclipse.org/releases/neon"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="false" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group" version="1.9.0.20160606-1526"/>
+      <unit id="org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group" version="1.9.0.20160606-1526"/>
+      <repository location="http://download.eclipse.org/ecp/releases/releases_19/190/"/>
+    </location>
+  </locations>
 </target>

--- a/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.tpd
+++ b/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.tpd
@@ -1,0 +1,66 @@
+target "Triq" with configurePhase
+
+location "http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/" {
+	org.slf4j.impl.log4j12
+	org.slf4j.api.source
+	org.slf4j.api
+	org.apache.commons.lang
+	org.slf4j.impl.log4j12.source
+	org.apache.commons.io.source
+	org.apache.log4j.source
+	org.apache.commons.io
+	org.apache.commons.lang.source
+	org.apache.log4j
+}
+
+location "http://users.telenet.be/triquetrum-ptolemy-p2/" {
+	org.eclipse.triquetrum.ptolemy.feature.source.feature.group lazy
+	org.eclipse.triquetrum.ptolemy.feature.feature.group lazy
+}
+
+location "http://archive.eclipse.org/nebula/Q42015/release/" {
+	org.eclipse.nebula.visualization.feature.feature.group
+}
+
+location "http://download.eclipse.org/releases/neon" {
+	org.eclipse.ecf.core.feature.feature.group
+	org.eclipse.emf.validation.feature.group
+	org.eclipse.platform.source.feature.group
+	org.eclipse.equinox.sdk.feature.group
+	org.eclipse.ecf.filetransfer.ssl.feature.feature.group
+	org.eclipse.equinox.core.sdk.feature.group
+	org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group
+	org.eclipse.platform.feature.group
+	org.eclipse.rcp.feature.group
+	org.eclipse.ocl.all.feature.group
+	org.eclipse.rcp.source.feature.group
+	org.eclipse.emf.cdo.epp.feature.group
+	org.eclipse.pde.source.feature.group
+	org.eclipse.gef.sdk.feature.group
+	org.eclipse.core.runtime.feature.feature.group
+	org.eclipse.emf.transaction.sdk.feature.group
+	org.eclipse.graphiti.feature.feature.group
+	org.eclipse.gmf.runtime.notation.source.feature.group
+	org.eclipse.ecf.filetransfer.feature.feature.group
+	org.eclipse.emf.sdk.feature.group
+	org.eclipse.gmf.source.feature.group
+	org.eclipse.gmf.tooling.runtime.source.feature.group
+	org.eclipse.graphiti.export.feature.feature.group
+	org.eclipse.graphiti.feature.tools.feature.group
+	org.eclipse.jdt.source.feature.group
+	org.eclipse.graphiti.sdk.feature.feature.group
+	org.eclipse.ecf.core.ssl.feature.feature.group
+	org.eclipse.gmf.feature.group
+	org.eclipse.net4j.util.ui.feature.group
+	org.eclipse.equinox.p2.sdk.feature.group
+	org.eclipse.net4j.ui.feature.group
+	org.eclipse.gmf.tooling.runtime.feature.group
+	org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group
+	org.eclipse.gmf.runtime.notation.feature.group
+	org.eclipse.graphiti.sdk.plus.feature.feature.group
+}
+
+location "http://download.eclipse.org/ecp/releases/releases_19/190/" {
+	org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group
+	org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group
+}


### PR DESCRIPTION
Instead of using .target files directly, instead use tpd files (Target
Platform Definition DSL and Generator files, from
https://github.com/mbarbero/fr.obeo.releng.targetplatform). This allows
a textual representation of the target platform that is easier to read,
edit and merge than the xml one.

Signed-off-by: Jonah Graham <jonah@kichwacoders.com>