### PR TITLE
Revert "Fixed multi-platform build after last change for Bug #66"

### DIFF
--- a/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
+++ b/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="triq" sequenceNumber="56">
+<?pde version="3.8"?><target name="triq" sequenceNumber="55">
 <locations>
 <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.nebula.visualization.feature.feature.group" version="0.9.9.201601121647"/>
@@ -66,10 +66,6 @@
 <unit id="org.apache.commons.lang.source" version="2.6.0.v201404270220"/>
 <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20151118145958/repository/"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.swt.dummyfragments.feature.group" version="1.0.0.v20160603-0902"/>
-<repository location="https://eclipseguru.github.io/missing-swt-fragments/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
Reverts eclipse/triquetrum#101

Backing out failed port to Neon.

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>