### PR TITLE
Triquetrum now builds on Neon, fixing Bug #104

### DIFF
--- a/org.eclipse.triquetrum.repository/Triquetrum.product
+++ b/org.eclipse.triquetrum.repository/Triquetrum.product
@@ -46,48 +46,68 @@
       <feature id="org.eclipse.triquetrum.rcp.feature" version="1.0.0.qualifier"/>
       <feature id="org.eclipse.triquetrum.workflow.actor.plot.feature" version="1.0.0.qualifier"/>
       <feature id="org.eclipse.triquetrum.python.feature" version="1.0.0.qualifier"/>
-      <feature id="org.eclipse.core.runtime.feature" version="1.1.101.v20150903-1804"/>
+      <feature id="org.eclipse.core.runtime.feature"/>
       <feature id="org.eclipse.ecf.core.feature"/>
       <feature id="org.eclipse.ecf.core.ssl.feature"/>
       <feature id="org.eclipse.ecf.filetransfer.feature"/>
       <feature id="org.eclipse.ecf.filetransfer.httpclient4.feature"/>
       <feature id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature"/>
       <feature id="org.eclipse.ecf.filetransfer.ssl.feature"/>
-      <feature id="org.eclipse.emf.common" version="2.11.0.v20150805-0538"/>
-      <feature id="org.eclipse.emf.common.ui" version="2.10.0.v20150806-0404"/>
-      <feature id="org.eclipse.emf.databinding" version="1.4.0.v20150806-0404"/>
-      <feature id="org.eclipse.emf.databinding.edit" version="1.4.0.v20150806-0404"/>
-      <feature id="org.eclipse.emf.ecore" version="2.11.1.v20150805-0538"/>
-      <feature id="org.eclipse.emf.ecore.edit" version="2.9.0.v20150806-0404"/>
-      <feature id="org.eclipse.emf.edit" version="2.11.1.v20150806-0404"/>
-      <feature id="org.eclipse.emf.edit.ui" version="2.11.0.v20150806-0404"/>
-      <feature id="org.eclipse.emf.transaction" version="1.9.0.201506010221"/>
-      <feature id="org.eclipse.emf.validation" version="1.9.0.201505312255"/>
-      <feature id="org.eclipse.emf.workspace" version="1.9.0.201506010221"/>
-      <feature id="org.eclipse.equinox.core.sdk" version="3.11.1.v20150831-1342"/>
-      <feature id="org.eclipse.equinox.p2.core.feature" version="1.3.100.v20150527-1706"/>
-      <feature id="org.eclipse.equinox.p2.discovery.feature" version="1.0.300.v20150430-1836"/>
-      <feature id="org.eclipse.equinox.p2.extras.feature" version="1.2.100.v20150601-1708"/>
-      <feature id="org.eclipse.equinox.p2.rcp.feature" version="1.2.101.v20150826-1318"/>
-      <feature id="org.eclipse.equinox.p2.user.ui" version="2.2.101.v20150826-1318"/>
-      <feature id="org.eclipse.gef" version="3.10.1.201508170204"/>
-      <feature id="org.eclipse.graphiti.feature" version="0.12.1.v20150916-0905"/>
-      <feature id="org.eclipse.graphiti.feature.tools" version="0.12.1.v20150916-0905"/>
-      <feature id="org.eclipse.graphiti.export.feature" version="0.12.1.v20150916-0905"/>
+      <feature id="org.eclipse.emf.common"/>
+      <feature id="org.eclipse.emf.common.ui"/>
+      <feature id="org.eclipse.emf.databinding"/>
+      <feature id="org.eclipse.emf.databinding.edit"/>
+      <feature id="org.eclipse.emf.ecore"/>
+      <feature id="org.eclipse.emf.ecore.edit"/>
+      <feature id="org.eclipse.emf.edit"/>
+      <feature id="org.eclipse.emf.edit.ui"/>
+      <feature id="org.eclipse.emf.transaction"/>
+      <feature id="org.eclipse.emf.validation"/>
+      <feature id="org.eclipse.emf.workspace"/>
+      <feature id="org.eclipse.equinox.core.sdk"/>
+      <feature id="org.eclipse.equinox.p2.core.feature"/>
+      <feature id="org.eclipse.equinox.p2.discovery.feature"/>
+      <feature id="org.eclipse.equinox.p2.extras.feature"/>
+      <feature id="org.eclipse.equinox.p2.rcp.feature"/>
+      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.gef"/>
+      <feature id="org.eclipse.graphiti.feature"/>
+      <feature id="org.eclipse.graphiti.feature.tools"/>
+      <feature id="org.eclipse.graphiti.export.feature"/>
       <feature id="org.eclipse.help"/>
-      <feature id="org.eclipse.jdt" version="3.11.1.v20150904-0015"/>
-      <feature id="org.eclipse.net4j" version="4.4.1.v20150912-0814"/>
-      <feature id="org.eclipse.net4j.util" version="4.4.1.v20150820-0533"/>
-      <feature id="org.eclipse.ocl" version="3.5.0.v20150525-1635"/>
-      <feature id="org.eclipse.pde" version="3.11.1.v20150904-0345"/>
-      <feature id="org.eclipse.platform" version="4.5.1.v20150904-0015"/>
+      <feature id="org.eclipse.jdt"/>
+      <feature id="org.eclipse.net4j"/>
+      <feature id="org.eclipse.net4j.util"/>
+      <feature id="org.eclipse.ocl"/>
+      <feature id="org.eclipse.pde"/>
+      <feature id="org.eclipse.platform"/>
       <feature id="org.eclipse.rcp"/>
       <feature id="org.eclipse.emf.ecp.e3.feature" version="1.8.0.20160216-1319"/>
       <feature id="org.eclipse.emf.ecp.emfforms.runtime.feature" version="1.8.0.20160216-1319"/>
       <feature id="org.eclipse.emf.ecp.view.template.feature" version="1.8.0.20160216-1319"/>
       <feature id="org.eclipse.emf.ecp.viewmodel.feature" version="1.8.0.20160216-1319"/>
-      <feature id="org.eclipse.gmf.runtime.thirdparty" version="1.9.0.201506060219"/>
+      <feature id="org.eclipse.gmf.runtime.thirdparty"/>
       <feature id="org.eclipse.emf.ecp.view.table.celleditor.rcp.feature" version="1.8.0.20160216-1319"/>
+      <feature id="org.eclipse.emf.ecp.view.treemasterdetail.feature"/>
+      <feature id="org.eclipse.triquetrum.ptolemy.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.label.feature"/>
+      <feature id="org.eclipse.triquetrum.core.feature"/>
+      <feature id="org.eclipse.emf.ecp.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.table.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.categorization.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.group.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.vertical.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.custom.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.stack.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.compoundcontrol.feature"/>
+      <feature id="org.eclipse.triquetrum.thirdparty.feature"/>
+      <feature id="org.eclipse.triquetrum.workflow.rcp.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.validation.feature"/>
+      <feature id="org.eclipse.triquetrum.workflow.core.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.rule.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.unset.feature"/>
+      <feature id="org.eclipse.emf.ecp.view.horizontal.feature"/>
+      <feature id="org.eclipse.e4.rcp"/>
    </features>
 
    <configurations>

--- a/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
+++ b/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Triq" sequenceNumber="1467831027">
+<?pde?>
+<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
+<target name="Triq" sequenceNumber="1472504501">
   <locations>
-    <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.2.101.v20150826-1312"/>
+      <repository location="http://download.eclipse.org/releases/mars/201510021000"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.slf4j.api.source" version="1.7.2.v20121108-1250"/>
       <unit id="org.slf4j.impl.log4j12.source" version="1.7.2.v20131105-2200"/>
       <unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
@@ -28,58 +34,61 @@
       <unit id="javax.activation" version="1.1.0.v201211130549"/>
       <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20151118145958/repository/"/>
     </location>
-    <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.triquetrum.ptolemy.feature.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.triquetrum.ptolemy.feature.feature.group" version="0.0.0"/>
       <repository location="http://users.telenet.be/triquetrum-ptolemy-p2/"/>
     </location>
-    <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.nebula.visualization.feature.feature.group" version="0.9.9.201601121647"/>
       <repository location="http://archive.eclipse.org/nebula/Q42015/release/"/>
     </location>
-    <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.1.0.v20150810-1719"/>
-      <unit id="org.eclipse.emf.validation.feature.group" version="1.9.0.201505312255"/>
-      <unit id="org.eclipse.platform.source.feature.group" version="4.5.1.v20150904-0015"/>
-      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.11.1.v20150831-1342"/>
-      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.0.0.v20150810-1719"/>
-      <unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.11.1.v20150831-1342"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.0.0.v20150810-1719"/>
-      <unit id="org.eclipse.platform.feature.group" version="4.5.1.v20150904-0015"/>
-      <unit id="org.eclipse.rcp.feature.group" version="4.5.1.v20150904-0015"/>
-      <unit id="org.eclipse.ocl.all.feature.group" version="5.1.0.v20150525-1635"/>
-      <unit id="org.eclipse.rcp.source.feature.group" version="4.5.1.v20150904-0015"/>
-      <unit id="org.eclipse.emf.cdo.epp.feature.group" version="4.4.1.v20150916-0832"/>
-      <unit id="org.eclipse.pde.source.feature.group" version="3.11.1.v20150904-0345"/>
-      <unit id="org.eclipse.gef.sdk.feature.group" version="3.10.1.201508170204"/>
-      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.1.101.v20150903-1804"/>
-      <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.9.0.201506010221"/>
-      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.12.1.v20150916-0905"/>
-      <unit id="org.eclipse.gmf.runtime.notation.source.feature.group" version="1.9.0.201505312221"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.10.1.v20150810-1719"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.11.1.v20150806-0404"/>
-      <unit id="org.eclipse.gmf.source.feature.group" version="1.9.0.201506060219"/>
-      <unit id="org.eclipse.gmf.tooling.runtime.source.feature.group" version="3.3.1.201509020853"/>
-      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.12.1.v20150916-0905"/>
-      <unit id="org.eclipse.graphiti.feature.tools.feature.group" version="0.12.1.v20150916-0905"/>
-      <unit id="org.eclipse.jdt.source.feature.group" version="3.11.1.v20150904-0015"/>
-      <unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.12.1.v20150916-0905"/>
-      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.0.0.v20150810-1719"/>
-      <unit id="org.eclipse.gmf.feature.group" version="1.9.0.201506060219"/>
-      <unit id="org.eclipse.net4j.util.ui.feature.group" version="4.4.1.v20150911-1807"/>
-      <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.9.100.v20150601-1708"/>
-      <unit id="org.eclipse.net4j.ui.feature.group" version="4.2.200.v20150911-1807"/>
-      <unit id="org.eclipse.gmf.tooling.runtime.feature.group" version="3.3.1.201509020853"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.10.1.v20150810-1719"/>
-      <unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.9.0.201505312221"/>
-      <unit id="org.eclipse.graphiti.sdk.plus.feature.feature.group" version="0.12.1.v20150916-0905"/>
-      <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.2.101.v20150826-1312"/>
-      <repository location="http://download.eclipse.org/releases/mars/201510021000"/>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.3.0.v20160405-1820"/>
+      <unit id="org.eclipse.emf.validation.feature.group" version="1.10.0.201606071713"/>
+      <unit id="org.eclipse.platform.source.feature.group" version="4.6.0.v20160606-1342"/>
+      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.12.0.v20160606-1311"/>
+      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.12.0.v20160603-1336"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.6.0.v20160606-1342"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.6.0.v20160606-1342"/>
+      <unit id="org.eclipse.ocl.all.feature.group" version="5.2.0.v20160523-1914"/>
+      <unit id="org.eclipse.rcp.source.feature.group" version="4.6.0.v20160606-1342"/>
+      <unit id="org.eclipse.emf.cdo.epp.feature.group" version="4.5.0.v20160607-1511"/>
+      <unit id="org.eclipse.pde.source.feature.group" version="3.12.0.v20160606-1100"/>
+      <unit id="org.eclipse.gef.sdk.feature.group" version="3.11.0.201606061308"/>
+      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.1.200.v20160606-1342"/>
+      <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.10.0.201606071900"/>
+      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.13.0.v20160608-1043"/>
+      <unit id="org.eclipse.gmf.runtime.notation.source.feature.group" version="1.10.0.201606071631"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.13.1.v20160405-1820"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.12.0.v20160526-0356"/>
+      <unit id="org.eclipse.gmf.source.feature.group" version="1.10.0.201606071959"/>
+      <unit id="org.eclipse.gmf.tooling.runtime.source.feature.group" version="3.3.1.201509291144"/>
+      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.13.0.v20160608-1043"/>
+      <unit id="org.eclipse.graphiti.feature.tools.feature.group" version="0.13.0.v20160608-1043"/>
+      <unit id="org.eclipse.jdt.source.feature.group" version="3.12.0.v20160606-1100"/>
+      <unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.13.0.v20160608-1043"/>
+      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.gmf.feature.group" version="1.10.0.201606071959"/>
+      <unit id="org.eclipse.net4j.util.ui.feature.group" version="4.5.0.v20160607-1254"/>
+      <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.9.200.v20160606-1311"/>
+      <unit id="org.eclipse.net4j.ui.feature.group" version="4.2.300.v20160301-1326"/>
+      <unit id="org.eclipse.gmf.tooling.runtime.feature.group" version="3.3.1.201509291144"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.13.1.v20160405-1820"/>
+      <unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.10.0.201606071631"/>
+      <unit id="org.eclipse.graphiti.sdk.plus.feature.feature.group" version="0.13.0.v20160608-1043"/>
+      <repository location="http://download.eclipse.org/releases/neon"/>
     </location>
-    <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group" version="1.8.0.20160216-1319"/>
       <unit id="org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group" version="1.8.0.20160216-1319"/>
       <repository location="http://download.eclipse.org/ecp/releases/releases_18/180/"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.swt.dummyfragments.feature.group" version="1.0.0.v20160603-0902"/>
+      <repository location="http://eclipseguru.github.io/missing-swt-fragments/"/>
     </location>
   </locations>
 </target>

--- a/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.tpd
+++ b/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.tpd
@@ -30,8 +30,7 @@ location "http://archive.eclipse.org/nebula/Q42015/release/" {
 	org.eclipse.nebula.visualization.feature.feature.group
 }
 
-// Force only to use the Mars.1 repo, remove the date suffix to use latest Mars
-location "http://download.eclipse.org/releases/mars/201510021000" {
+location "http://download.eclipse.org/releases/neon" {
 	org.eclipse.ecf.core.feature.feature.group
 	org.eclipse.emf.validation.feature.group
 	org.eclipse.platform.source.feature.group
@@ -72,4 +71,10 @@ location "http://download.eclipse.org/releases/mars/201510021000" {
 location "http://download.eclipse.org/ecp/releases/releases_18/180/" {
 	org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group
 	org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group
+}
+
+// Add swt dummy fragments so that we can build installers for multiple platforms.
+// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=491951#c35
+location "http://eclipseguru.github.io/missing-swt-fragments/" {
+	org.eclipse.swt.dummyfragments.feature.group
 }


### PR DESCRIPTION
Note that we need to use swt fragments because of Bug #491951:  Unable
to satisfy dependency from org.eclipse.swt v20160317 to
org.eclipse.swt.gtk.linux.aarch64, see
https://bugs.eclipse.org/bugs/show_bug.cgi?id=491951#c35

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>