### PR TITLE
Use the new ptII p2 repo.  Bug #114

### DIFF
--- a/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
+++ b/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
@@ -1,91 +1,88 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde?>
-<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="Triq" sequenceNumber="1472507242">
-  <locations>
-    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.slf4j.api.source" version="1.7.2.v20121108-1250"/>
-      <unit id="org.slf4j.impl.log4j12.source" version="1.7.2.v20131105-2200"/>
-      <unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
-      <unit id="org.apache.log4j.source" version="1.2.15.v201012070815"/>
-      <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-      <unit id="org.apache.commons.lang.source" version="2.6.0.v201404270220"/>
-      <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
-      <unit id="org.apache.commons.codec" version="1.6.0.v201305230611"/>
-      <unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
-      <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
-      <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
-      <unit id="org.apache.ws.commons.util" version="1.0.1.v20100518-1140"/>
-      <unit id="org.apache.xmlrpc" version="3.0.0.v20100427-1100"/>
-      <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
-      <unit id="org.hamcrest.generator" version="1.3.0.v201305210900"/>
-      <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
-      <unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
-      <unit id="org.junit" version="4.12.0.v201504281640"/>
-      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-      <unit id="org.slf4j.impl.log4j12" version="1.7.2.v20131105-2200"/>
-      <unit id="javax.xml" version="1.3.4.v201005080400"/>
-      <unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
-      <unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
-      <unit id="javax.activation" version="1.1.0.v201211130549"/>
-      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20151118145958/repository/"/>
-    </location>
-    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.eclipse.triquetrum.ptolemy.feature.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.triquetrum.ptolemy.feature.feature.group" version="0.0.0"/>
-      <repository location="http://users.telenet.be/triquetrum-ptolemy-p2/"/>
-    </location>
-    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.eclipse.nebula.visualization.feature.feature.group" version="0.9.9.201601121647"/>
-      <repository location="http://archive.eclipse.org/nebula/Q42015/release/"/>
-    </location>
-    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.3.0.v20160405-1820"/>
-      <unit id="org.eclipse.emf.validation.feature.group" version="1.10.0.201606071713"/>
-      <unit id="org.eclipse.platform.source.feature.group" version="4.6.0.v20160606-1342"/>
-      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.12.0.v20160606-1311"/>
-      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
-      <unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.12.0.v20160603-1336"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
-      <unit id="org.eclipse.platform.feature.group" version="4.6.0.v20160606-1342"/>
-      <unit id="org.eclipse.rcp.feature.group" version="4.6.0.v20160606-1342"/>
-      <unit id="org.eclipse.ocl.all.feature.group" version="5.2.0.v20160523-1914"/>
-      <unit id="org.eclipse.rcp.source.feature.group" version="4.6.0.v20160606-1342"/>
-      <unit id="org.eclipse.emf.cdo.epp.feature.group" version="4.5.0.v20160607-1511"/>
-      <unit id="org.eclipse.pde.source.feature.group" version="3.12.0.v20160606-1100"/>
-      <unit id="org.eclipse.gef.sdk.feature.group" version="3.11.0.201606061308"/>
-      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.1.200.v20160606-1342"/>
-      <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.10.0.201606071900"/>
-      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.13.0.v20160608-1043"/>
-      <unit id="org.eclipse.gmf.runtime.notation.source.feature.group" version="1.10.0.201606071631"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.13.1.v20160405-1820"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.12.0.v20160526-0356"/>
-      <unit id="org.eclipse.gmf.source.feature.group" version="1.10.0.201606071959"/>
-      <unit id="org.eclipse.gmf.tooling.runtime.source.feature.group" version="3.3.1.201509291144"/>
-      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.13.0.v20160608-1043"/>
-      <unit id="org.eclipse.graphiti.feature.tools.feature.group" version="0.13.0.v20160608-1043"/>
-      <unit id="org.eclipse.jdt.source.feature.group" version="3.12.0.v20160606-1100"/>
-      <unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.13.0.v20160608-1043"/>
-      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
-      <unit id="org.eclipse.gmf.feature.group" version="1.10.0.201606071959"/>
-      <unit id="org.eclipse.net4j.util.ui.feature.group" version="4.5.0.v20160607-1254"/>
-      <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.9.200.v20160606-1311"/>
-      <unit id="org.eclipse.net4j.ui.feature.group" version="4.2.300.v20160301-1326"/>
-      <unit id="org.eclipse.gmf.tooling.runtime.feature.group" version="3.3.1.201509291144"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.13.1.v20160405-1820"/>
-      <unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.10.0.201606071631"/>
-      <unit id="org.eclipse.graphiti.sdk.plus.feature.feature.group" version="0.13.0.v20160608-1043"/>
-      <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.3.0.v20160603-1336"/>
-      <repository location="http://download.eclipse.org/releases/neon/"/>
-    </location>
-    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group" version="1.8.0.20160216-1319"/>
-      <unit id="org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group" version="1.8.0.20160216-1319"/>
-      <repository location="http://download.eclipse.org/ecp/releases/releases_18/180/"/>
-    </location>
-    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.eclipse.swt.dummyfragments.feature.group" version="1.0.0.v20160603-0902"/>
-      <repository location="http://eclipseguru.github.io/missing-swt-fragments/"/>
-    </location>
-  </locations>
+<?pde version="3.8"?><target name="Triq" sequenceNumber="1472584552">
+<locations>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+<unit id="org.slf4j.api.source" version="1.7.2.v20121108-1250"/>
+<unit id="org.slf4j.impl.log4j12.source" version="1.7.2.v20131105-2200"/>
+<unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
+<unit id="org.apache.log4j.source" version="1.2.15.v201012070815"/>
+<unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
+<unit id="org.apache.commons.lang.source" version="2.6.0.v201404270220"/>
+<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+<unit id="org.apache.commons.codec" version="1.6.0.v201305230611"/>
+<unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
+<unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
+<unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
+<unit id="org.apache.ws.commons.util" version="1.0.1.v20100518-1140"/>
+<unit id="org.apache.xmlrpc" version="3.0.0.v20100427-1100"/>
+<unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
+<unit id="org.hamcrest.generator" version="1.3.0.v201305210900"/>
+<unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
+<unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
+<unit id="org.junit" version="4.12.0.v201504281640"/>
+<unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
+<unit id="org.slf4j.impl.log4j12" version="1.7.2.v20131105-2200"/>
+<unit id="javax.xml" version="1.3.4.v201005080400"/>
+<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
+<unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
+<unit id="javax.activation" version="1.1.0.v201211130549"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20151118145958/repository/"/>
+</location>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+<unit id="org.ptolemy.tycho.feature.feature.group" version="0.0.0"/>
+<repository location="https://chess.eecs.berkeley.edu/triq/p2/osgi-2-0/"/>
+</location>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+<unit id="org.eclipse.nebula.visualization.feature.feature.group" version="0.9.9.201601121647"/>
+<repository location="http://archive.eclipse.org/nebula/Q42015/release/"/>
+</location>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+<unit id="org.eclipse.ecf.core.feature.feature.group" version="1.3.0.v20160405-1820"/>
+<unit id="org.eclipse.emf.validation.feature.group" version="1.10.0.201606071713"/>
+<unit id="org.eclipse.platform.source.feature.group" version="4.6.0.v20160606-1342"/>
+<unit id="org.eclipse.equinox.sdk.feature.group" version="3.12.0.v20160606-1311"/>
+<unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+<unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.12.0.v20160603-1336"/>
+<unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+<unit id="org.eclipse.platform.feature.group" version="4.6.0.v20160606-1342"/>
+<unit id="org.eclipse.rcp.feature.group" version="4.6.0.v20160606-1342"/>
+<unit id="org.eclipse.ocl.all.feature.group" version="5.2.0.v20160523-1914"/>
+<unit id="org.eclipse.rcp.source.feature.group" version="4.6.0.v20160606-1342"/>
+<unit id="org.eclipse.emf.cdo.epp.feature.group" version="4.5.0.v20160607-1511"/>
+<unit id="org.eclipse.pde.source.feature.group" version="3.12.0.v20160606-1100"/>
+<unit id="org.eclipse.gef.sdk.feature.group" version="3.11.0.201606061308"/>
+<unit id="org.eclipse.core.runtime.feature.feature.group" version="1.1.200.v20160606-1342"/>
+<unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.10.0.201606071900"/>
+<unit id="org.eclipse.graphiti.feature.feature.group" version="0.13.0.v20160608-1043"/>
+<unit id="org.eclipse.gmf.runtime.notation.source.feature.group" version="1.10.0.201606071631"/>
+<unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.13.1.v20160405-1820"/>
+<unit id="org.eclipse.emf.sdk.feature.group" version="2.12.0.v20160526-0356"/>
+<unit id="org.eclipse.gmf.source.feature.group" version="1.10.0.201606071959"/>
+<unit id="org.eclipse.gmf.tooling.runtime.source.feature.group" version="3.3.1.201509291144"/>
+<unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.13.0.v20160608-1043"/>
+<unit id="org.eclipse.graphiti.feature.tools.feature.group" version="0.13.0.v20160608-1043"/>
+<unit id="org.eclipse.jdt.source.feature.group" version="3.12.0.v20160606-1100"/>
+<unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.13.0.v20160608-1043"/>
+<unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+<unit id="org.eclipse.gmf.feature.group" version="1.10.0.201606071959"/>
+<unit id="org.eclipse.net4j.util.ui.feature.group" version="4.5.0.v20160607-1254"/>
+<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.9.200.v20160606-1311"/>
+<unit id="org.eclipse.net4j.ui.feature.group" version="4.2.300.v20160301-1326"/>
+<unit id="org.eclipse.gmf.tooling.runtime.feature.group" version="3.3.1.201509291144"/>
+<unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.13.1.v20160405-1820"/>
+<unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.10.0.201606071631"/>
+<unit id="org.eclipse.graphiti.sdk.plus.feature.feature.group" version="0.13.0.v20160608-1043"/>
+<unit id="org.eclipse.equinox.core.feature.feature.group" version="1.3.0.v20160603-1336"/>
+<repository location="http://download.eclipse.org/releases/neon/"/>
+</location>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+<unit id="org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group" version="1.8.0.20160216-1319"/>
+<unit id="org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group" version="1.8.0.20160216-1319"/>
+<repository location="http://download.eclipse.org/ecp/releases/releases_18/180/"/>
+</location>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+<unit id="org.eclipse.swt.dummyfragments.feature.group" version="1.0.0.v20160603-0902"/>
+<repository location="http://eclipseguru.github.io/missing-swt-fragments/"/>
+</location>
+</locations>
 </target>

--- a/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.tpd
+++ b/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.tpd
@@ -21,9 +21,14 @@ location "http://download.eclipse.org/tools/orbit/downloads/drops/R2015111814595
 //	org.apache.log4j
 }
 
-location "http://users.telenet.be/triquetrum-ptolemy-p2/" {
-	org.eclipse.triquetrum.ptolemy.feature.source.feature.group lazy
-	org.eclipse.triquetrum.ptolemy.feature.feature.group lazy
+// Leave the previous site commented out until the new site is definitely working
+//location "http://users.telenet.be/triquetrum-ptolemy-p2/" {
+//	org.eclipse.triquetrum.ptolemy.feature.source.feature.group lazy
+//	org.eclipse.triquetrum.ptolemy.feature.feature.group lazy
+//}
+
+location "https://chess.eecs.berkeley.edu/triq/p2/osgi-2-0/" {
+	org.ptolemy.tycho.feature.feature.group lazy
 }
 
 location "http://archive.eclipse.org/nebula/Q42015/release/" {


### PR DESCRIPTION
Use the new ptII repo at
https://chess.eecs.berkeley.edu/triq/p2/osgi-2-0/

See
https://wiki.eclipse.org/Triquetrum/Ptolemy/osgi-2-0#The_Ptolemy_II_osgi-2-0_p2_repository

This will allow Bug #114 Create a p2 site for the Ptolemy II bundles  
to be closed

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>