### PR TITLE
Added target to print env to help solve proxy problem. Bug #492412

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,30 @@
             </execution>
           </executions>
         </plugin>
+
+	<!-- Echo then environment variables
+	     See https://bugs.eclipse.org/bugs/show_bug.cgi?id=492412
+	  -->
+	<plugin>
+	  <groupId>org.apache.maven.plugins</groupId>
+	  <artifactId>maven-antrun-plugin</artifactId>
+	  <version>1.6</version>
+	  <executions>
+	    <execution>
+	      <id>ini</id>
+	      <phase>initialize</phase>
+	      <goals>
+		<goal>run</goal>
+	      </goals>
+	      <configuration>
+		<target>
+		  <property environment="env" />
+		  <echoproperties prefix="env." />
+		</target>
+	      </configuration>
+	    </execution>
+	  </executions>
+        </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
The Hudson Triquetrum build cannot access 
https://chess.eecs.berkeley.edu/triq/p2/osgi-2-0/

It could be a proxy problem during the "mvn clean install" process

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>