### PR TITLE
Update version from 1.0 to 0.1.0 for incubation. Bug #129

### DIFF
--- a/examples/org.eclipse.triquetrum.python.service.example/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.triquetrum.python.service.example/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Python RPC Example (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.python.service.example
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: iSencia
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.osgi.framework.console,

--- a/examples/org.eclipse.triquetrum.workflow.actor.plot.palette/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.triquetrum.workflow.actor.plot.palette/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Palette entry for XYPlotActor (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.actor.plot.palette;singleton:=true
-Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.triquetrum.workflow.editor;bundle-version="1.0.0"
+Bundle-Version: 0.1.0.qualifier
+Require-Bundle: org.eclipse.triquetrum.workflow.editor;bundle-version="0.1.0"
 Bundle-Vendor: Eclipse Triquetrum

--- a/examples/org.eclipse.triquetrum.workflow.actor.plot/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.triquetrum.workflow.actor.plot/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Plot actors for Triquetrum (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.actor.plot
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Activator: org.eclipse.triquetrum.workflow.actor.plot.activator.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum

--- a/org.eclipse.triquetrum.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.common/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum Common (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.common
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: Eclipse Triquetrum
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.triquetrum;version="1.0.0"

--- a/org.eclipse.triquetrum.dependencies/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.dependencies/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum Dependencies (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.dependencies
-Bundle-Version: 0.0.1.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: deps/ptII/org.ptolemy.commons_11.0.0.201511291558.jar,
  deps/ptII/ptolemy.actor.lib.gui_11.0.0.201601302217.jar,

--- a/org.eclipse.triquetrum.logging.dvp/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.logging.dvp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Dvp logging config (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.logging.dvp
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Fragment-Host: org.apache.log4j;bundle-version="1.2.15"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum

--- a/org.eclipse.triquetrum.processing.actor/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.processing.actor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Processing Actor implementations (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.processing.actor
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Activator: org.eclipse.triquetrum.processing.actor.activator.Activator
 Bundle-Vendor: Eclipse Triquetrum
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.triquetrum.processing.api/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.processing.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum process model API (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.processing.api
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
 Import-Package: org.eclipse.triquetrum;version="1.0.0",

--- a/org.eclipse.triquetrum.processing.model.impl/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.processing.model.impl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum process model in-memory implementation (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.processing.model.impl.memory
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
 Import-Package: org.apache.commons.lang.builder;version="2.6.0",

--- a/org.eclipse.triquetrum.processing.service.impl.example/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.processing.service.impl.example/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Task processing service examples (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.processing.service.impl.example
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.triquetrum;version="1.0.0",
  org.eclipse.triquetrum.processing;version="1.0.0",

--- a/org.eclipse.triquetrum.processing.service.impl/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.processing.service.impl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum task processing service implementations (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.processing.service.impl
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
 Import-Package: org.eclipse.triquetrum;version="1.0.0",

--- a/org.eclipse.triquetrum.processing.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.processing.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Triquetrum processing API and implementations (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.processing.test
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.triquetrum;version="1.0.0",
  org.eclipse.triquetrum.processing;version="1.0.0",

--- a/org.eclipse.triquetrum.python.actor/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.python.actor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Python Actor bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.python.actor
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Activator: org.eclipse.triquetrum.python.actor.activator.Activator
 Bundle-Vendor: Eclipse Triquetrum
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.triquetrum.python.service/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.python.service/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Python RPC Service (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.python.service
-Bundle-Version: 1.0.4
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.triquetrum.python.service;version="1.0.4",
  org.eclipse.triquetrum.python.service.util;version="1.0.4"

--- a/org.eclipse.triquetrum.repository/Triquetrum.product
+++ b/org.eclipse.triquetrum.repository/Triquetrum.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Triquetrum" uid="org.eclipse.triquetrum.workflow.editor.rcp.incubation" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="1.0.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Triquetrum" uid="org.eclipse.triquetrum.workflow.editor.rcp.incubation" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="0.1.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <image path="eclipse_lg.png"/>

--- a/org.eclipse.triquetrum.scisoft.analysis.rpc.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.scisoft.analysis.rpc.test/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xmlrpc (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.scisoft.analysis.rpc.test
-Bundle-Version: 1.0.0.qualifier
-Fragment-Host: org.eclipse.triquetrum.scisoft.analysis.rpc;bundle-version="1.0.0"
+Bundle-Version: 0.1.0.qualifier
+Fragment-Host: org.eclipse.triquetrum.scisoft.analysis.rpc;bundle-version="0.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="[4.10.0,5.0.0)",
  org.eclipse.equinox.common

--- a/org.eclipse.triquetrum.scisoft.analysis.rpc/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.scisoft.analysis.rpc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: DLS Analysis RPC subset for passerelle (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.scisoft.analysis.rpc
-Bundle-Version: 1.0.0
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.triquetrum.scisoft.analysis.rpc,
  org.eclipse.triquetrum.scisoft.analysis.rpc.flattening,

--- a/org.eclipse.triquetrum.validation.api/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.validation.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum Validation Api (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.validation.api
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: Eclipse Triquetrum
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.triquetrum.validation;version="1.0.0",

--- a/org.eclipse.triquetrum.workflow.actor.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.actor.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Actor UI integration (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.actor.ui
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
 Import-Package: org.eclipse.swt,
@@ -19,5 +19,5 @@ Import-Package: org.eclipse.swt,
  ptolemy.kernel.util;version="11.0.0",
  ptolemy.util;version="11.0.0"
 Bundle-Activator: org.eclipse.triquetrum.workflow.actor.ui.activator.Activator
-Require-Bundle: org.eclipse.triquetrum.workflow.ui;bundle-version="1.0.0"
+Require-Bundle: org.eclipse.triquetrum.workflow.ui;bundle-version="0.1.0"
 

--- a/org.eclipse.triquetrum.workflow.api/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum Workflow Execution Api (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.api
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: Eclipse Triquetrum
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.triquetrum;version="1.0.0",

--- a/org.eclipse.triquetrum.workflow.editor.palette/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.editor.palette/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Default Triquetrum editor palette (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.editor.palette;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Require-Bundle: org.eclipse.triquetrum.workflow.editor
 Import-Package: ptolemy.actor;version="11.0.0",
  ptolemy.actor.lib;version="11.0.0",

--- a/org.eclipse.triquetrum.workflow.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum Workflow Editor (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.editor;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
 Require-Bundle: org.eclipse.graphiti;bundle-version="0.12.0",

--- a/org.eclipse.triquetrum.workflow.execution.impl/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.execution.impl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum Workflow Execution Impl (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.execution.impl
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
 Import-Package: org.apache.commons.lang.builder;version="2.6.0",

--- a/org.eclipse.triquetrum.workflow.model.edit/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.model.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.model.edit;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.triquetrum.workflow.model.provider.TriquetrumEditPlugin$Implementation
 Bundle-Vendor: Eclipse Triquetrum

--- a/org.eclipse.triquetrum.workflow.model.editor/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.model.editor/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.triquetrum.workflow.model.presentation
 Bundle-Name: %pluginName (Incubation)
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.triquetrum.workflow.model.presentation.T

--- a/org.eclipse.triquetrum.workflow.model.viewmodel/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.model.viewmodel/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.triquetrum.workflow.model.viewmodel (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.model.viewmodel;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Require-Bundle: org.eclipse.emf.ecp.view.model.provider.xmi
 Bundle-Vendor: Eclipse Triquetrum

--- a/org.eclipse.triquetrum.workflow.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.model;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport

--- a/org.eclipse.triquetrum.workflow.repository.impl.filesystem/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.repository.impl.filesystem/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Workflow repository on the file system (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.repository.impl.filesystem
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
 Import-Package: org.apache.commons.io;version="2.2.0",

--- a/org.eclipse.triquetrum.workflow.repository.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.repository.test/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Triquetrum workflow execution tests (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.execution.test
-Bundle-Version: 1.0.0.qualifier
-Fragment-Host: org.eclipse.triquetrum.workflow.repository.impl.filesystem;bundle-version="1.0.0.qualifier"
+Bundle-Version: 0.1.0.qualifier
+Fragment-Host: org.eclipse.triquetrum.workflow.repository.impl.filesystem;bundle-version="0.1.0.qualifier"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
 Import-Package: junit.framework;version="4.12.0",

--- a/org.eclipse.triquetrum.workflow.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.triquetrum.workflow.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Workflow UI integration (Incubation)
 Bundle-SymbolicName: org.eclipse.triquetrum.workflow.ui
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
 Import-Package: org.eclipse.swt,


### PR DESCRIPTION
https://www.eclipse.org/projects/handbook/#release-faq

Version numbers of incubation products should be less than 1.0.

Used the following command:

sed -i ''  's/\(^Bundle-Version:.*$\)/Bundle-Version: 0.1.0.qualifier/'
examples/*/META-INF/MANIFEST.MF *triq*/META-INF/MANIFEST.MF


Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>