### PR TITLE
Bug #141: Provide python its own input channel

### DIFF
--- a/org.eclipse.triquetrum.python.service/src/main/java/org/eclipse/triquetrum/python/service/PythonService.java
+++ b/org.eclipse.triquetrum.python.service/src/main/java/org/eclipse/triquetrum/python/service/PythonService.java
@@ -78,7 +78,7 @@ public class PythonService {
     environment.put("PYTHONPATH", pyBuf.toString());
 
     // TODO: log back python output directly to the log file.
-    processBuilder.redirectInput(Redirect.INHERIT);
+    processBuilder.redirectInput(Redirect.PIPE);
     processBuilder.redirectOutput(Redirect.INHERIT);
     processBuilder.redirectError(Redirect.INHERIT);
     service.process = processBuilder.start();


### PR DESCRIPTION
Stop trying to reuse the input channel of Eclipse. When Eclipse is
run with -console (OSGi console) then Eclipse is already reading
from stdin. That means that Python is not able to and on Windows
it does not start properly.

Signed-off-by: Jonah Graham <jonah@kichwacoders.com>