### PR TITLE
Added copyZips rule for Bug#148 Releases on Eclipse Downloads

### DIFF
--- a/org.eclipse.triquetrum.repository/publish.xml
+++ b/org.eclipse.triquetrum.repository/publish.xml
@@ -68,6 +68,36 @@ sites. This includes:
         </copy>
     </target>
 
+    <!-- ================================================================= -->
+    <!-- C O P Y Z I P S                                                   -->
+    <!-- ================================================================= -->
+    <target name="copyZips"
+            description="Copies *.zip files in a source directory to a target directory.">
+
+      
+        <!-- To test, use:
+	     ant -file publish.xml -DtargetDir=/tmp/testPub/ -DsourceDir=target/products/ copyZips
+	  -->
+        <!-- Empty the target directory -->
+        <delete dir="${targetDir}" />
+
+        <!-- Recreate the target directory. It can happen that this task
+             fails seemingly at random. To be sure, we wrap it in a retry
+             task that repeats the mkdir call up to 10 times, with a pause
+             between each pair of attempts (the retrydelay is measured in
+             milliseconds). -->
+        <retry retrycount="10" retrydelay="1000">
+            <mkdir dir="${targetDir}" />
+        </retry>
+
+        <!-- Copy to target directory -->
+        <copy todir="${targetDir}">
+            <fileset dir="${sourceDir}">
+	      <include name="*.zip"/>
+	    </fileset>
+        </copy>
+    </target>
+
 
     <!-- ================================================================= -->
     <!-- Z I P   I T                                                       -->


### PR DESCRIPTION
Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>