### PR TITLE
Added '(Incubation)' to the category and feature names

### DIFF
--- a/examples/org.eclipse.triquetrum.workflow.actor.plot.feature/feature.xml
+++ b/examples/org.eclipse.triquetrum.workflow.actor.plot.feature/feature.xml
@@ -11,7 +11,7 @@
  -->
 <feature
       id="org.eclipse.triquetrum.workflow.actor.plot.feature"
-      label="%featureName"
+      label="%featureName (Incubation)"
       version="0.1.0.qualifier"
       provider-name="%providerName">
 

--- a/org.eclipse.triquetrum.core.feature/feature.xml
+++ b/org.eclipse.triquetrum.core.feature/feature.xml
@@ -11,7 +11,7 @@
  -->
 <feature
       id="org.eclipse.triquetrum.core.feature"
-      label="%featureName"
+      label="%featureName (Incubation)"
       version="0.1.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.triquetrum.processing.api">

--- a/org.eclipse.triquetrum.ptolemy.feature/feature.xml
+++ b/org.eclipse.triquetrum.ptolemy.feature/feature.xml
@@ -11,7 +11,7 @@
  -->
 <feature
       id="org.eclipse.triquetrum.ptolemy.feature"
-      label="%featureName"
+      label="%featureName (Incubation)"
       version="0.1.0.qualifier"
       provider-name="%providerName">
 

--- a/org.eclipse.triquetrum.python.feature/feature.xml
+++ b/org.eclipse.triquetrum.python.feature/feature.xml
@@ -11,7 +11,7 @@
  -->
 <feature
       id="org.eclipse.triquetrum.python.feature"
-      label="%featureName"
+      label="%featureName (Incubation)"
       version="0.1.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.triquetrum.python.service">

--- a/org.eclipse.triquetrum.rcp.feature/feature.xml
+++ b/org.eclipse.triquetrum.rcp.feature/feature.xml
@@ -11,7 +11,7 @@
  -->
 <feature
       id="org.eclipse.triquetrum.rcp.feature"
-      label="%featureName"
+      label="%featureName (Incubation)"
       version="0.1.0.qualifier"
       provider-name="%providerName">
 

--- a/org.eclipse.triquetrum.thirdparty.feature/feature.xml
+++ b/org.eclipse.triquetrum.thirdparty.feature/feature.xml
@@ -11,7 +11,7 @@
  -->
 <feature
       id="org.eclipse.triquetrum.thirdparty.feature"
-      label="%featureName"
+      label="%featureName (Incubation)"
       version="0.1.0.qualifier"
       provider-name="%providerName">
 

--- a/org.eclipse.triquetrum.update/category.xml
+++ b/org.eclipse.triquetrum.update/category.xml
@@ -24,7 +24,7 @@
    <feature url="features/org.eclipse.triquetrum.workflow.rcp.feature_0.1.0.qualifier.jar" id="org.eclipse.triquetrum.workflow.rcp.feature" version="0.1.0.qualifier">
       <category name="triquetrum"/>
    </feature>
-   <category-def name="triquetrum" label="Triquetrum Scientific Workflow System">
+   <category-def name="triquetrum" label="Triquetrum Scientific Workflow System (Incubation)">
       <description>
          Triquetrum delivers an open platform for managing and executing scientific workflows. The goal of Triquetrum is to support a wide range of use cases, ranging from automated processes based on predefined models, to replaying ad-hoc research workflows recorded from a user&apos;s actions in a scientific workbench UI. It will allow to define and execute models from personal pipelines with a few steps to massive models with thousands of elements.
       </description>

--- a/org.eclipse.triquetrum.workflow.core.feature/feature.xml
+++ b/org.eclipse.triquetrum.workflow.core.feature/feature.xml
@@ -11,7 +11,7 @@
  -->
 <feature
       id="org.eclipse.triquetrum.workflow.core.feature"
-      label="%featureName"
+      label="%featureName (Incubation)"
       version="0.1.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.triquetrum.workflow.api">

--- a/org.eclipse.triquetrum.workflow.rcp.feature/feature.xml
+++ b/org.eclipse.triquetrum.workflow.rcp.feature/feature.xml
@@ -11,7 +11,7 @@
  -->
 <feature
       id="org.eclipse.triquetrum.workflow.rcp.feature"
-      label="%featureName"
+      label="%featureName (Incubation)"
       version="0.1.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.triquetrum.workflow.editor">


### PR DESCRIPTION
Bug #145 Create a p2 repository

The incubation guide requires:
'6. Similarly, the names for update manager features must include the
word "incubation". For example, Eclipse Platform (Incubation)"'

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>