### PR TITLE
Mac OS: Added -data /tmp to prevent translocation message.

### DIFF
--- a/org.eclipse.triquetrum.repository/Triquetrum.product
+++ b/org.eclipse.triquetrum.repository/Triquetrum.product
@@ -14,6 +14,8 @@
    </configIni>
 
    <launcherArgs>
+      <programArgsMac>-data /tmp
+      </programArgsMac>
       <vmArgs>-Dosgi.requiredJavaVersion=1.7 -Xms256m -Xmx1024m -Djava.net.preferIPv4Stack=true
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
@@ -27,7 +29,6 @@
       startupMessageRect="7,265,320,20"
       startupForegroundColor="9c9696" />
    <launcher name="triquetrum">
-      <solaris/>
       <win useIco="false">
          <bmp/>
       </win>


### PR DESCRIPTION
https://github.com/eclipse/triquetrum/issues/224

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>