### PR TITLE
Set osgi.requiredJavaVersion to 1.8: Bug #227

### DIFF
--- a/org.eclipse.triquetrum.repository/Triquetrum.product
+++ b/org.eclipse.triquetrum.repository/Triquetrum.product
@@ -16,7 +16,7 @@
    <launcherArgs>
       <programArgsMac>-data /tmp
       </programArgsMac>
-      <vmArgs>-Dosgi.requiredJavaVersion=1.7 -Xms256m -Xmx1024m -Djava.net.preferIPv4Stack=true
+      <vmArgs>-Dosgi.requiredJavaVersion=1.8 -Xms256m -Xmx1024m -Djava.net.preferIPv4Stack=true
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -155,6 +155,26 @@
    </configurations>
 
    <repositories>
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
+      <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
       <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
       <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />
       <repository location="http://download.eclipse.org/triquetrum/update" enabled="true" />


### PR DESCRIPTION
Linux download fails to find modules
https://github.com/eclipse/triquetrum/issues/227


Erwin replied:

> I think this is due to the fact that you launch your RCP on a JDK 7
(cfr the 3rd line in the startup log). 
> Since Neon, Eclipse requires a JDK 8 to run on itself (although you
can develop in it for Java 7 applications or older).


Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>