### PR TITLE
Updated paths of Windows and Mac Binaries

### DIFF
--- a/org.eclipse.triquetrum.repository/pom.xml
+++ b/org.eclipse.triquetrum.repository/pom.xml
@@ -114,10 +114,10 @@ Contributors: Erwin De Ley - initial API and implementation and/or initial docum
               <phase>package</phase>
 	      <configuration>
                 <signFiles>
-                  <signFile>org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0-SNAPSHOT.qualifier/win32/win32/x86/eclipsec.exe</signFile>
-                  <signFile>org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0-SNAPSHOT.qualifier/win32/win32/x86/triquetrum.exe</signFile>
-                  <signFile>org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0-SNAPSHOT.qualifier/win32/win32/x86_64/eclipsec.exe</signFile>
-                  <signFile>./org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0-SNAPSHOT.qualifier/win32/win32/x86_64/triquetrum.exe</signFile>
+                  <signFile>org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0.qualifier/win32/win32/x86/triquetrum-0.2.0-SNAPSHOT/eclipsec.exe</signFile>
+                  <signFile>org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0.qualifier/win32/win32/x86/triquetrum-0.2.0-SNAPSHOT/triquetrum.exe</signFile>
+                  <signFile>org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0.qualifier/win32/win32/x86_64/triquetrum-0.2.0-SNAPSHOT/eclipsec.exe</signFile>
+                  <signFile>org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0.qualifier/win32/win32/x86_64/triquetrum-0.2.0-SNAPSHOT/triquetrum.exe</signFile>
                 </signFiles>
 	      </configuration>
             </execution>
@@ -136,7 +136,7 @@ Contributors: Erwin De Ley - initial API and implementation and/or initial docum
               <phase>package</phase>
 	      <configuration>
                 <signFiles>
-                  <signFile>./org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0-SNAPSHOT.qualifier/macosx/cocoa/x86_64/Eclipse.app</signFile>
+                  <signFile>org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0.qualifier/macosx/cocoa/x86_64/triquetrum-0.2.0-SNAPSHOT.app</signFile>
                 </signFiles>
 	      </configuration>
             </execution>


### PR DESCRIPTION
RC1 Mac Installer is from an unknown developer
https://github.com/eclipse/triquetrum/issues/186


Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>