### PR TITLE
#219: fix wrapping of Ptolemy Port for e.g. RecordDisassembler

### DIFF
--- a/org.eclipse.triquetrum.workflow.editor/src/main/java/org/eclipse/triquetrum/workflow/editor/util/EditorUtils.java
+++ b/org.eclipse.triquetrum.workflow.editor/src/main/java/org/eclipse/triquetrum/workflow/editor/util/EditorUtils.java
@@ -522,6 +522,10 @@ public class EditorUtils {
       }
       relationContainer.getRelations().add(relation);
       relation.welcome(new PtObjectBuilderAndApplierVisitor(), true);
+      // need to make sure that source and target ports have their Pt wrapped object in order as well,
+      // before doing all the linking.
+      source.welcome(new PtObjectBuilderAndApplierVisitor(), true);
+      target.welcome(new PtObjectBuilderAndApplierVisitor(), true);
       ((Linkable) source).link(relation);
       ((Linkable) target).link(relation);
     }


### PR DESCRIPTION
Ports created in EMF Form were not guaranteed to have their Ptolemy
wrappedObject available when drawing connections on them.

Signed-off-by: Erwin De Ley <erwindl0@gmail.com>