### PR TITLE
Bug #259: Remove dependency on missing swt-fragments

### DIFF
--- a/releng/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
+++ b/releng/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.target
@@ -1,89 +1,87 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Triq" sequenceNumber="1503865024">
-<locations>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="javax.activation" version="1.1.0.v201211130549"/>
-<unit id="javax.servlet" version="3.1.0.v201410161800"/>
-<unit id="javax.xml" version="1.3.4.v201005080400"/>
-<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
-<unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
-<unit id="org.apache.commons.codec" version="1.9.0.v20170208-1614"/>
-<unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
-<unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
-<unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
-<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
-<unit id="org.apache.commons.lang.source" version="2.6.0.v201404270220"/>
-<unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
-<unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
-<unit id="org.apache.log4j.source" version="1.2.15.v201012070815"/>
-<unit id="org.apache.ws.commons.util" version="1.0.2.v20160817-1930"/>
-<unit id="org.apache.xmlrpc.client" version="3.1.3.v20160817-1930"/>
-<unit id="org.apache.xmlrpc.common" version="3.1.3.v20160817-1930"/>
-<unit id="org.apache.xmlrpc.server" version="3.1.3.v20160817-1930"/>
-<unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
-<unit id="org.hamcrest.generator" version="1.3.0.v201305210900"/>
-<unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
-<unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
-<unit id="org.junit" version="4.12.0.v201504281640"/>
-<unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-<unit id="org.slf4j.api.source" version="1.7.2.v20121108-1250"/>
-<unit id="org.slf4j.impl.log4j12" version="1.7.2.v20131105-2200"/>
-<unit id="org.slf4j.impl.log4j12.source" version="1.7.2.v20131105-2200"/>
-<repository location="http://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.ptolemy.tycho.feature.feature.group" version="0.0.0"/>
-<repository location="http://chess.eecs.berkeley.edu/triq/p2/osgi-2-0-2/"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.nebula.visualization.feature.feature.group" version="1.0.0.201605182147"/>
-<repository location="http://archive.eclipse.org/nebula/Q22016/release/"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.core.runtime.feature.feature.group" version="1.2.0.v20170518-1049"/>
-<unit id="org.eclipse.ecf.core.feature.feature.group" version="1.4.0.v20170516-2248"/>
-<unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20170110-1317"/>
-<unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.13.7.v20170516-2248"/>
-<unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.13.7.v20170516-2248"/>
-<unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20170110-1317"/>
-<unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20170110-1317"/>
-<unit id="org.eclipse.emf.cdo.epp.feature.group" version="4.6.0.v20170602-1611"/>
-<unit id="org.eclipse.emf.sdk.feature.group" version="2.13.0.v20170609-0928"/>
-<unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.11.0.201706061339"/>
-<unit id="org.eclipse.emf.validation.feature.group" version="1.11.0.201706061352"/>
-<unit id="org.eclipse.equinox.core.feature.feature.group" version="1.4.0.v20170518-1049"/>
-<unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.13.0.v20170516-1513"/>
-<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.10.0.v20170524-1345"/>
-<unit id="org.eclipse.equinox.sdk.feature.group" version="3.13.0.v20170531-1133"/>
-<unit id="org.eclipse.gef.sdk.feature.group" version="3.11.0.201606061308"/>
-<unit id="org.eclipse.gmf.feature.group" version="1.11.0.201706061437"/>
-<unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.11.0.201706061354"/>
-<unit id="org.eclipse.gmf.runtime.notation.source.feature.group" version="1.11.0.201706061354"/>
-<unit id="org.eclipse.gmf.source.feature.group" version="1.11.0.201706061437"/>
-<unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.14.0.201705161212"/>
-<unit id="org.eclipse.graphiti.feature.feature.group" version="0.14.0.201705161212"/>
-<unit id="org.eclipse.graphiti.feature.tools.feature.group" version="0.14.0.201705161212"/>
-<unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.14.0.201705161212"/>
-<unit id="org.eclipse.graphiti.sdk.plus.feature.feature.group" version="0.14.0.201705161212"/>
-<unit id="org.eclipse.jdt.source.feature.group" version="3.13.0.v20170612-0950"/>
-<unit id="org.eclipse.net4j.ui.feature.group" version="4.2.400.v20161018-1819"/>
-<unit id="org.eclipse.net4j.util.ui.feature.group" version="4.6.0.v20170521-0536"/>
-<unit id="org.eclipse.ocl.all.feature.group" version="5.3.0.v20170522-1736"/>
-<unit id="org.eclipse.pde.source.feature.group" version="3.13.0.v20170612-0950"/>
-<unit id="org.eclipse.platform.feature.group" version="4.7.0.v20170612-1255"/>
-<unit id="org.eclipse.platform.source.feature.group" version="4.7.0.v20170612-1255"/>
-<unit id="org.eclipse.rcp.feature.group" version="4.7.0.v20170612-1255"/>
-<unit id="org.eclipse.rcp.source.feature.group" version="4.7.0.v20170612-1255"/>
-<repository location="http://download.eclipse.org/releases/oxygen/"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group" version="1.13.1.20170711-0730"/>
-<unit id="org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group" version="1.13.1.20170711-0730"/>
-<repository location="http://download.eclipse.org/ecp/releases/releases_113/"/>
-</location>
-<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.swt.dummyfragments.feature.group" version="1.0.0.v20170228-0512"/>
-<repository location="http://eclipseguru.github.io/missing-swt-fragments/"/>
-</location>
-</locations>
+<?pde?>
+<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
+<target name="Triq" sequenceNumber="1504028820">
+  <locations>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.slf4j.api.source" version="1.7.2.v20121108-1250"/>
+      <unit id="org.slf4j.impl.log4j12.source" version="1.7.2.v20131105-2200"/>
+      <unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
+      <unit id="org.apache.log4j.source" version="1.2.15.v201012070815"/>
+      <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
+      <unit id="org.apache.commons.lang.source" version="2.6.0.v201404270220"/>
+      <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+      <unit id="org.apache.commons.codec" version="1.9.0.v20170208-1614"/>
+      <unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
+      <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
+      <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
+      <unit id="org.apache.ws.commons.util" version="1.0.2.v20160817-1930"/>
+      <unit id="org.apache.xmlrpc.client" version="3.1.3.v20160817-1930"/>
+      <unit id="org.apache.xmlrpc.common" version="3.1.3.v20160817-1930"/>
+      <unit id="org.apache.xmlrpc.server" version="3.1.3.v20160817-1930"/>
+      <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
+      <unit id="org.hamcrest.generator" version="1.3.0.v201305210900"/>
+      <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
+      <unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
+      <unit id="org.junit" version="4.12.0.v201504281640"/>
+      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
+      <unit id="org.slf4j.impl.log4j12" version="1.7.2.v20131105-2200"/>
+      <unit id="javax.xml" version="1.3.4.v201005080400"/>
+      <unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
+      <unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
+      <unit id="javax.activation" version="1.1.0.v201211130549"/>
+      <unit id="javax.servlet" version="3.1.0.v201410161800"/>
+      <repository location="http://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.ptolemy.tycho.feature.feature.group" version="0.0.0"/>
+      <repository location="http://chess.eecs.berkeley.edu/triq/p2/osgi-2-0-2/"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.nebula.visualization.feature.feature.group" version="1.0.0.201605182147"/>
+      <repository location="http://archive.eclipse.org/nebula/Q22016/release/"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.4.0.v20170516-2248"/>
+      <unit id="org.eclipse.emf.validation.feature.group" version="1.11.0.201706061352"/>
+      <unit id="org.eclipse.platform.source.feature.group" version="4.7.0.v20170612-1255"/>
+      <unit id="org.eclipse.equinox.sdk.feature.group" version="3.13.0.v20170531-1133"/>
+      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20170110-1317"/>
+      <unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.13.0.v20170516-1513"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20170110-1317"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.7.0.v20170612-1255"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.7.0.v20170612-1255"/>
+      <unit id="org.eclipse.ocl.all.feature.group" version="5.3.0.v20170522-1736"/>
+      <unit id="org.eclipse.rcp.source.feature.group" version="4.7.0.v20170612-1255"/>
+      <unit id="org.eclipse.emf.cdo.epp.feature.group" version="4.6.0.v20170602-1611"/>
+      <unit id="org.eclipse.pde.source.feature.group" version="3.13.0.v20170612-0950"/>
+      <unit id="org.eclipse.gef.sdk.feature.group" version="3.11.0.201606061308"/>
+      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.2.0.v20170518-1049"/>
+      <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.11.0.201706061339"/>
+      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.14.0.201705161212"/>
+      <unit id="org.eclipse.gmf.runtime.notation.source.feature.group" version="1.11.0.201706061354"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.13.7.v20170516-2248"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.13.0.v20170609-0928"/>
+      <unit id="org.eclipse.gmf.source.feature.group" version="1.11.0.201706061437"/>
+      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.14.0.201705161212"/>
+      <unit id="org.eclipse.graphiti.feature.tools.feature.group" version="0.14.0.201705161212"/>
+      <unit id="org.eclipse.jdt.source.feature.group" version="3.13.0.v20170612-0950"/>
+      <unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.14.0.201705161212"/>
+      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20170110-1317"/>
+      <unit id="org.eclipse.gmf.feature.group" version="1.11.0.201706061437"/>
+      <unit id="org.eclipse.net4j.util.ui.feature.group" version="4.6.0.v20170521-0536"/>
+      <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.10.0.v20170524-1345"/>
+      <unit id="org.eclipse.net4j.ui.feature.group" version="4.2.400.v20161018-1819"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.13.7.v20170516-2248"/>
+      <unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.11.0.201706061354"/>
+      <unit id="org.eclipse.graphiti.sdk.plus.feature.feature.group" version="0.14.0.201705161212"/>
+      <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.4.0.v20170518-1049"/>
+      <repository location="http://download.eclipse.org/releases/oxygen/"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="false" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group" version="1.13.1.20170711-0730"/>
+      <unit id="org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group" version="1.13.1.20170711-0730"/>
+      <repository location="http://download.eclipse.org/ecp/releases/releases_113/"/>
+    </location>
+  </locations>
 </target>

--- a/releng/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.tpd
+++ b/releng/org.eclipse.triquetrum.target.platform/org.eclipse.triquetrum.target.platform.tpd
@@ -75,9 +75,3 @@ location "http://download.eclipse.org/ecp/releases/releases_113/" {
 	org.eclipse.emf.ecp.view.table.celleditor.rcp.feature.source.feature.group
 	org.eclipse.emf.ecp.emfforms.sdk.feature.feature.group
 }
-
-// Add swt dummy fragments so that we can build installers for multiple platforms.
-// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=491951#c35
-location "http://eclipseguru.github.io/missing-swt-fragments/" {
-	org.eclipse.swt.dummyfragments.feature.group
-}


### PR DESCRIPTION
See Bug 491951 - Unable to satisfy dependency from org.eclipse.swt
v20160317 to org.eclipse.swt.gtk.linux.aarch64

See
Bug #101 Fixed multi-platform build after last change for Bug #66

Bug #259 Update build to not use
http://eclipseguru.github.io/missing-swt-fragments/ 

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>