### PR TITLE
Bug #266: Added vendor to o.e.t.w.aoc.repository

### DIFF
--- a/plugins/core/org.eclipse.triquetrum.workflow.aoc.repository/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.workflow.aoc.repository/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package: org.eclipse.triquetrum;version="0.1.0",
  ptolemy.kernel;version="11.0.0"
 Service-Component: OSGI-INF/AocProviderFromRepository.xml
 Bundle-ActivationPolicy: lazy
+Bundle-Vendor: Eclipse Triquetrum


### PR DESCRIPTION
Bug #266: org.eclipse.triquetrum.workflow.aoc.repository is 
not signed 

The issue here was that there was no value for vendor in
MANIFEST.MF.

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>