### PR TITLE
Bug #215 Updated aoc vendor to Eclipse Triquetrum.

### DIFF
--- a/plugins/core/org.eclipse.triquetrum.workflow.aoc.repository/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.workflow.aoc.repository/META-INF/MANIFEST.MF
@@ -13,4 +13,4 @@ Import-Package: org.eclipse.triquetrum;version="0.1.0",
  ptolemy.kernel;version="11.0.0"
 Service-Component: OSGI-INF/AocProviderFromRepository.xml
 Bundle-ActivationPolicy: lazy
-Bundle-Vendor: iSencia Belgium NV
+Bundle-Vendor: Eclipse Triquetrum


### PR DESCRIPTION
Initially, the org.eclipse.triquetrum.workflow.aoc.repository
bundle had iSencia as the vendor.  I changed it to
iSencia Belgium NV or something similar.  Erwin correctly
pointed out that as this bundle is in the triquetrum repo,
it should have Eclipse Triquetrum as the vendor.

Some of the bundles in the osgi-2-0 correctly have iScencia 
Belgium NV as the vendor.

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>