### PR TITLE
Bug #281	. Copy .tar.gz files to the download directory

### DIFF
--- a/releng/org.eclipse.triquetrum.repository/publish.xml
+++ b/releng/org.eclipse.triquetrum.repository/publish.xml
@@ -96,6 +96,11 @@ sites. This includes:
 	      <include name="*.zip"/>
 	    </fileset>
         </copy>
+        <copy todir="${targetDir}">
+            <fileset dir="${sourceDir}">
+          <include name="*.tar.gz"/>
+        </fileset>
+        </copy>
     </target>
 
 


### PR DESCRIPTION
Bug #281 Release Triquetrum 0.2.0

https://github.com/eclipse/triquetrum/issues/281

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>