### PR TITLE
Bug #281: Update Versions: Adding more pom.xml files

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.triquetrum</groupId>
 		<artifactId>org.eclipse.triquetrum.build</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.triquetrum</groupId>
 		<artifactId>org.eclipse.triquetrum.build</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/plugins/core/pom.xml
+++ b/plugins/core/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.triquetrum</groupId>
 		<artifactId>org.eclipse.triquetrum.plugins</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/plugins/editor/pom.xml
+++ b/plugins/editor/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.triquetrum</groupId>
 		<artifactId>org.eclipse.triquetrum.plugins</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/plugins/extras/pom.xml
+++ b/plugins/extras/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.triquetrum</groupId>
 		<artifactId>org.eclipse.triquetrum.plugins</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.eclipse.triquetrum</groupId>
 		<artifactId>org.eclipse.triquetrum.build</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.triquetrum</groupId>
-  <version>0.2.0-SNAPSHOT</version>
+  <version>0.2.0</version>
 
   <!-- Changed artifactId to org.eclipse.triquetrum.build -->
   <!-- <artifactId>triquetrum</artifactId> -->


### PR DESCRIPTION
Missed some pom.xml files in the previous commit.

https://github.com/eclipse/triquetrum/issues/281

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>