### PR TITLE
Bug #281 Release Triquetrum 0.2.0.  Updated to version 0.2.0

### DIFF
--- a/releng/org.eclipse.triquetrum.repository/pom.xml
+++ b/releng/org.eclipse.triquetrum.repository/pom.xml
@@ -65,7 +65,7 @@ Contributors: Erwin De Ley - initial API and implementation and/or initial docum
           <product>
             <!-- select product with ID product.id; the archives get the classifiers "<os>.<ws>.<arch>" -->
             <id>org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0</id>
-            <rootFolder>triquetrum-0.2.0.RC1</rootFolder>
+            <rootFolder>triquetrum-0.2.0</rootFolder>
           </product>
         </products>
       </configuration>
@@ -115,10 +115,10 @@ Contributors: Erwin De Ley - initial API and implementation and/or initial docum
               <phase>package</phase>
 	      <configuration>
                 <signFiles>
-                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/win32/win32/x86/triquetrum-0.2.0.RC1/eclipsec.exe</signFile>
-                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/win32/win32/x86/triquetrum-0.2.0.RC1/triquetrum.exe</signFile>
-                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/win32/win32/x86_64/triquetrum-0.2.0.RC1/eclipsec.exe</signFile>
-                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/win32/win32/x86_64/triquetrum-0.2.0.RC1/triquetrum.exe</signFile>
+                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/win32/win32/x86/triquetrum-0.2.0/eclipsec.exe</signFile>
+                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/win32/win32/x86/triquetrum-0.2.0/triquetrum.exe</signFile>
+                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/win32/win32/x86_64/triquetrum-0.2.0/eclipsec.exe</signFile>
+                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/win32/win32/x86_64/triquetrum-0.2.0/triquetrum.exe</signFile>
                 </signFiles>
 	      </configuration>
             </execution>
@@ -137,7 +137,7 @@ Contributors: Erwin De Ley - initial API and implementation and/or initial docum
               <phase>package</phase>
 	      <configuration>
                 <signFiles>
-                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/macosx/cocoa/x86_64/triquetrum-0.2.0.RC1.app</signFile>
+                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.0/macosx/cocoa/x86_64/triquetrum-0.2.0.app</signFile>
                 </signFiles>
 	      </configuration>
             </execution>


### PR DESCRIPTION
https://github.com/eclipse/triquetrum/issues/281

Signed-off-by: Christopher Brooks <cxh@eecs.berkeley.edu>