### PR TITLE
Eclipse no longer supports 32-bit images, so don't try to sign them.

### DIFF
--- a/releng/org.eclipse.triquetrum.repository/pom.xml
+++ b/releng/org.eclipse.triquetrum.repository/pom.xml
@@ -115,8 +115,6 @@ Contributors: Erwin De Ley - initial API and implementation and/or initial docum
               <phase>package</phase>
 	      <configuration>
                 <signFiles>
-                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.1/win32/win32/x86/triquetrum-0.2.1/eclipsec.exe</signFile>
-                  <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.1/win32/win32/x86/triquetrum-0.2.1/triquetrum.exe</signFile>
                   <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.1/win32/win32/x86_64/triquetrum-0.2.1/eclipsec.exe</signFile>
                   <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.2.1/win32/win32/x86_64/triquetrum-0.2.1/triquetrum.exe</signFile>
                 </signFiles>


### PR DESCRIPTION
Triquetrum Bug #315 Create 0.3.0M1 release

Signed-off-by: Christopher Brooks <cxbrooks@gmail.com>