### PR TITLE
Added Eclipse-SourceReference.

### DIFF
--- a/examples/org.eclipse.triquetrum.processing.service.impl.example/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.triquetrum.processing.service.impl.example/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Import-Package: org.eclipse.triquetrum;version="0.1.0",
 Bundle-Vendor: Eclipse Triquetrum
 Service-Component: OSGI-INF/MathsProcessingService.xml
 Export-Package: org.eclipse.triquetrum.processing.service.impl.example
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/examples/org.eclipse.triquetrum.python.service.example/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.triquetrum.python.service.example/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Service-Component: OSGI-INF/component.xml
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.equinox.common
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/examples/org.eclipse.triquetrum.workflow.actor.plot.palette/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.triquetrum.workflow.actor.plot.palette/META-INF/MANIFEST.MF
@@ -5,3 +5,4 @@ Bundle-SymbolicName: org.eclipse.triquetrum.workflow.actor.plot.palette;singleto
 Bundle-Version: 0.2.0.qualifier
 Require-Bundle: org.eclipse.triquetrum.workflow.editor;bundle-version="0.1.0"
 Bundle-Vendor: Eclipse Triquetrum
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/examples/org.eclipse.triquetrum.workflow.actor.plot/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.triquetrum.workflow.actor.plot/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Import-Package: org.apache.commons.lang;version="2.6.0",
  ptolemy.util;version="11.0.0"
 Export-Package: org.eclipse.triquetrum.workflow.actor.plot;version="0.1.0"
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.common/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.common/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.triquetrum;version="0.1.0"
 Import-Package: ptolemy.data;version="10.1.0",
  ptolemy.kernel.util
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.logging.dvp/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.logging.dvp/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 0.2.0.qualifier
 Fragment-Host: org.apache.log4j;bundle-version="1.2.15"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.processing.actor/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.processing.actor/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Import-Package: org.eclipse.triquetrum;version="0.1.0",
  ptolemy.kernel;version="11.0.0",
  ptolemy.kernel.util;version="11.0.0"
 Export-Package: org.eclipse.triquetrum.processing.actor
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.processing.api/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.processing.api/META-INF/MANIFEST.MF
@@ -14,4 +14,4 @@ Import-Package: org.eclipse.triquetrum;version="0.1.0",
 Export-Package: org.eclipse.triquetrum.processing;version="0.1.0",
  org.eclipse.triquetrum.processing.model;version="0.1.0",
  org.eclipse.triquetrum.processing.service;version="0.1.0"
-
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.processing.model.impl/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.processing.model.impl/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package: org.apache.commons.lang.builder;version="2.6.0",
 Export-Package: org.eclipse.triquetrum.processing.model.impl;version="0.1.0"
 Service-Component: OSGI-INF/TriqFactory.xml
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.processing.service.impl/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.processing.service.impl/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package: org.eclipse.triquetrum;version="0.1.0",
 Service-Component: OSGI-INF/TaskProcessingBroker.xml
 Export-Package: org.eclipse.triquetrum.processing.service.impl;version="0.1.0"
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.validation.api/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.validation.api/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Export-Package: org.eclipse.triquetrum.validation;version="0.1.0",
  org.eclipse.triquetrum.validation.service;version="0.1.0"
 Import-Package: org.eclipse.triquetrum;version="0.1.0",
  ptolemy.kernel.util;version="10.1.0"
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.workflow.aoc.repository/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.workflow.aoc.repository/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package: org.eclipse.triquetrum;version="0.1.0",
 Service-Component: OSGI-INF/AocProviderFromRepository.xml
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse Triquetrum
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.workflow.api/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.workflow.api/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Export-Package: org.eclipse.triquetrum.workflow;version="0.2.0",
  org.eclipse.triquetrum.workflow.util;version="0.2.0"
 Service-Component: OSGI-INF/WorkflowRepositoryRegistry.xml
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.workflow.execution.impl/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.workflow.execution.impl/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package: org.apache.commons.lang.builder;version="2.6.0",
  ptolemy.kernel.util;version="11.0.0"
 Service-Component: OSGI-INF/WorkflowExecutionService.xml
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/core/org.eclipse.triquetrum.workflow.repository.impl.filesystem/META-INF/MANIFEST.MF
+++ b/plugins/core/org.eclipse.triquetrum.workflow.repository.impl.filesystem/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Import-Package: org.apache.commons.io;version="2.2.0",
 Bundle-Activator: org.eclipse.triquetrum.workflow.repository.impl.filesystem.activator.Activator
 Export-Package: org.eclipse.triquetrum.workflow.repository.impl.filesystem;version="0.2.0"
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.actor.ui/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.actor.ui/META-INF/MANIFEST.MF
@@ -22,4 +22,5 @@ Import-Package: org.eclipse.swt,
 Bundle-Activator: org.eclipse.triquetrum.workflow.actor.ui.activator.Activator
 Require-Bundle: org.eclipse.triquetrum.workflow.ui;bundle-version="0.1.0"
 Bundle-ActivationPolicy: lazy
-
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git
+  

--- a/plugins/editor/org.eclipse.triquetrum.workflow.editor.palette/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.editor.palette/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Import-Package: ptolemy.actor;version="11.0.0",
  ptolemy.vergil.kernel.attributes;version="11.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.editor/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.editor/META-INF/MANIFEST.MF
@@ -115,3 +115,4 @@ Bundle-Activator: org.eclipse.triquetrum.workflow.editor.TriqEditorPlugin
 Service-Component: OSGI-INF/colorRendererService.xml
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.triquetrum.workflow.editor.palette.spi
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.model.edit/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.model.edit/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.edit;visibility:=reexport,
  org.eclipse.ui.intro.universal
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.model.editor/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.model.editor/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Bundle-ClassPath: .
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.triquetrum.workflow.model.presentation.T
  riquetrumEditorPlugin$Implementation
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.model.viewmodel/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.model.viewmodel/META-INF/MANIFEST.MF
@@ -5,3 +5,4 @@ Bundle-SymbolicName: org.eclipse.triquetrum.workflow.model.viewmodel;singleton:=
 Bundle-Version: 0.3.0.qualifier
 Require-Bundle: org.eclipse.emf.ecp.view.model.provider.xmi
 Bundle-Vendor: Eclipse Triquetrum
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.model/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.model/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Import-Package: com.microstar.xml;version="10.1.0",
  ptolemy.moml;version="11.0.0",
  ptolemy.moml.filter;version="11.0.0",
  ptolemy.vergil.kernel.attributes;version="11.0.0"
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.rcp.common/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.rcp.common/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Export-Package: org.eclipse.triquetrum.workflow.rcp;version="0.2.0"
 Import-Package: org.eclipse.swt.dnd,
  org.eclipse.triquetrum.workflow;version="0.2.0"
 Require-Bundle: org.eclipse.ui;bundle-version="3.109.0"
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.repository.impl.filesystem.ui/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.repository.impl.filesystem.ui/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package: org.eclipse.core.commands.common,
  org.osgi.framework;version="1.8.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.triquetrum.workflow.repository.impl.filesystem.preferences.ui.WorkflowRepositoryUIPlugin
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.repository.ui/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.repository.ui/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package: org.eclipse.triquetrum;version="0.1.0",
  org.ptolemy.commons;version="11.0.0",
  org.slf4j;version="1.7.2",
  ptolemy.actor;version="11.0.0"
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/editor/org.eclipse.triquetrum.workflow.ui/META-INF/MANIFEST.MF
+++ b/plugins/editor/org.eclipse.triquetrum.workflow.ui/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Import-Package: org.eclipse.swt,
 Export-Package: org.eclipse.triquetrum.workflow.ui;version="0.1.0"
 Bundle-Activator: org.eclipse.triquetrum.workflow.ui.activator.Activator
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/extras/org.eclipse.triquetrum.python.actor.palette/META-INF/MANIFEST.MF
+++ b/plugins/extras/org.eclipse.triquetrum.python.actor.palette/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Import-Package: ptolemy.actor;version="11.0.0",
  ptolemy.vergil.kernel.attributes;version="11.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/extras/org.eclipse.triquetrum.python.actor/META-INF/MANIFEST.MF
+++ b/plugins/extras/org.eclipse.triquetrum.python.actor/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package: org.eclipse.triquetrum.python.service;version="0.1.0",
  ptolemy.kernel;version="11.0.0",
  ptolemy.kernel.util;version="11.0.0"
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/extras/org.eclipse.triquetrum.python.service/META-INF/MANIFEST.MF
+++ b/plugins/extras/org.eclipse.triquetrum.python.service/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Eclipse-BundleShape: dir
 Require-Bundle: org.eclipse.equinox.common
 Bundle-Vendor: Eclipse Triquetrum
 Bundle-ActivationPolicy: lazy
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/plugins/extras/org.eclipse.triquetrum.scisoft.analysis.rpc/META-INF/MANIFEST.MF
+++ b/plugins/extras/org.eclipse.triquetrum.scisoft.analysis.rpc/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package: org.apache.commons.lang,
  org.apache.xmlrpc.webserver,
  org.slf4j;version="1.6.0"
 Bundle-Vendor: Eclipse Triquetrum
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/tests/org.eclipse.triquetrum.logging.dvp/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.triquetrum.logging.dvp/META-INF/MANIFEST.MF
@@ -7,3 +7,4 @@ Bundle-Version: 0.2.0.qualifier
 Fragment-Host: org.apache.log4j;bundle-version="1.2.15"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse Triquetrum
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/tests/org.eclipse.triquetrum.processing.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.triquetrum.processing.test/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package: org.eclipse.triquetrum;version="0.1.0",
  org.osgi.service.component;version="1.2.2"
 Require-Bundle: org.junit
 Bundle-Vendor: Eclipse Triquetrum
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git

--- a/tests/org.eclipse.triquetrum.scisoft.analysis.rpc.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.triquetrum.scisoft.analysis.rpc.test/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Export-Package: org.eclipse.triquetrum.scisoft.analysis.rpc,
  org.eclipse.triquetrum.scisoft.analysis.rpc.staticdispatchertypes,
  org.eclipse.triquetrum.scisoft.analysis.rpc.test
 Eclipse-BundleShape: dir
+Eclipse-SourceReference: scm:git:https://github.com/eclipse/triquetrum.git


### PR DESCRIPTION
Eclipse Bug #328 Bundles should use Eclipse-SourceReferences

Signed-off-by: Christopher Brooks <cxbrooks@gmail.com>