### PR TITLE
Updated macOS signing to include Entitlements

### DIFF
--- a/entitlement/triquetrum.entitlement
+++ b/entitlement/triquetrum.entitlement
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Copied from https://github.com/eclipse/eclipse.platform.releng.aggregator/blob/master/eclipse.platform.releng.tychoeclipsebuilder/entitlement/sdk.entitlement -->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+</dict>
+</plist>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,23 @@
 	<properties>
 		<!-- Alphabetical below here. -->
 		<buildId>I${maven.build.timestamp}</buildId>
-		<cbi-plugins.version>1.1.3</cbi-plugins.version>
+
+                <!-- For the most recent version of cbi-plugins.version, 
+                     See https://github.com/eclipse/eclipse.platform.releng.aggregator/blob/master/eclipse-platform-parent/pom.xml -->
+		<cbi-plugins.version>1.1.8-SNAPSHOT</cbi-plugins.version>
+
 		<!-- Repo for released versions of CBI -->
 		<eclipse-repo.url>https://repo.eclipse.org/content/repositories/cbi/</eclipse-repo.url>
+
+                <!-- macSigner.forceContinue is used in releng/org.eclipse.triquetrum.repository/pom.xml -->
+                <macSigner.forceContinue>false</macSigner.forceContinue>
+
 		<maven-repo.url>https://repo1.maven.org/maven2/</maven-repo.url>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-		<releaseName>0.3.0</releaseName>
+                
+                <!-- FIXME: releaseName is not used and perhaps can be removed? -->
+		<releaseName>0.4.0</releaseName>
+                
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 		<tycho-version>1.6.0</tycho-version>
 	</properties>

--- a/releng/org.eclipse.triquetrum.repository/pom.xml
+++ b/releng/org.eclipse.triquetrum.repository/pom.xml
@@ -97,12 +97,13 @@
           <plugin>
             <groupId>org.eclipse.cbi.maven.plugins</groupId>
             <artifactId>eclipse-macsigner-plugin</artifactId>
-            <version>1.1.3</version>
+            <!-- cbi-plugins is set in ../../pom.xml -->
+            <version>${cbi-plugins.version}</version>
           </plugin>
           <plugin>
             <groupId>org.eclipse.cbi.maven.plugins</groupId>
             <artifactId>eclipse-winsigner-plugin</artifactId>
-            <version>1.1.3</version>
+            <version>${cbi-plugins.version}</version>
           </plugin>
         </plugins>
       </pluginManagement>
@@ -142,6 +143,10 @@
                 <signFiles>
                   <signFile>releng/org.eclipse.triquetrum.repository/target/products/org.eclipse.triquetrum.workflow.editor.rcp.incubation-0.4.0M1/macosx/cocoa/x86_64/triquetrum-0.4.0M1.app</signFile>
                 </signFiles>
+                <timeoutMillis>300000</timeoutMillis> <!-- 5 min -->
+                <continueOnFail>${macSigner.forceContinue}</continueOnFail>
+                <entitlements>${project.basedir}/../../entitlement/triquetrum.entitlement</entitlements>
+                <signerUrl>http://172.30.206.146:8282/macosx-signing-service/1.0.1-SNAPSHOT</signerUrl>
 	      </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
Bug #358 macOS: The JVM shared library ... does not contain the
JNI_CreateJavaVM symbol

See
https://wiki.eecs.berkeley.edu/ptexternal/Main/EclipseAndSigningMacApps

Signed-off-by: Christopher Brooks <cxbrooks@gmail.com>